### PR TITLE
fix: spell caster slots

### DIFF
--- a/src/modules/ActionHandler.mjs
+++ b/src/modules/ActionHandler.mjs
@@ -417,7 +417,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
         spellsMap.set(type, circleMap);
       }
 
-      for (const [circle, slot] of Object.entries(this.actor.system.spellcasting.slots)) {
+      for (const [circle, slot] of Object.entries(this.actor.system?.spellcasting?.slots ?? {})) {
         const value = slot?.value ?? '∞';
         const max = slot?.max ?? '∞';
 


### PR DESCRIPTION
fixes #2
 black-flag npcs do not have spell slots. fix adds optional chaining safety check so npc spell casters do not crash.